### PR TITLE
Fix warnings of type "H2443: Inline function '%s' has not been expand…

### DIFF
--- a/Source/GR32.pas
+++ b/Source/GR32.pas
@@ -44,9 +44,9 @@ interface
 
 uses
   {$IFDEF FPC} LCLIntf, LCLType, Types, {$ELSE}
-  {$IFDEF COMPILERXE2_UP}Types, {$ENDIF} Windows, {$ENDIF}
+  {$IFDEF COMPILERXE2_UP}UITypes, Types, {$ENDIF} Windows, {$ENDIF}
   Controls, Graphics, Classes, SysUtils;
-  
+
 { Version Control }
 
 const
@@ -1079,7 +1079,7 @@ var
 resourcestring
   RCStrUnmatchedReferenceCounting = 'Unmatched reference counting.';
   RCStrCannotSetSize = 'Can''t set size from ''%s''';
-  RCStrInpropriateBackend = 'Inpropriate Backend';
+  RCStrInpropriateBackend = 'Inappropriate Backend';
 
 implementation
 

--- a/Source/GR32_ColorGradients.pas
+++ b/Source/GR32_ColorGradients.pas
@@ -37,7 +37,7 @@ interface
 
 uses
   Types, Classes, SysUtils, Math, GR32, GR32_Polygons,
-  GR32_VectorUtils;
+  GR32_VectorUtils, GR32_Blend;
 
 type
   TColor32GradientStop = record
@@ -671,7 +671,7 @@ type
 implementation
 
 uses
-  GR32_Blend, GR32_LowLevel, GR32_System, GR32_Math, GR32_Bindings,
+  GR32_LowLevel, GR32_System, GR32_Math, GR32_Bindings,
   GR32_Geometry;
 
 resourcestring

--- a/Source/GR32_Containers.pas
+++ b/Source/GR32_Containers.pas
@@ -45,7 +45,7 @@ uses
   Types,
   {$ENDIF}
 {$ELSE}
-  Windows,
+  Types, Windows,
 {$ENDIF}
   RTLConsts,
   GR32, SysUtils, Classes, TypInfo;

--- a/Source/GR32_Filters.pas
+++ b/Source/GR32_Filters.pas
@@ -185,7 +185,7 @@ begin
     DstX := Clamp(DstX, 0, Width);
     DstY := Clamp(DstY, 0, Height);
 
-    DstRect.TopLeft := Point(DstX, DstY);
+    DstRect.TopLeft := GR32.Point(DstX, DstY);
     DstRect.Right := DstX + SrcRect.Right - SrcRect.Left;
     DstRect.Bottom := DstY + SrcRect.Bottom - SrcRect.Top;
 
@@ -484,7 +484,7 @@ begin
     DstX := Clamp(DstX, 0, Width);
     DstY := Clamp(DstY, 0, Height);
 
-    DstRect.TopLeft := Point(DstX, DstY);
+    DstRect.TopLeft := GR32.Point(DstX, DstY);
     DstRect.Right := DstX + SrcRect.Right - SrcRect.Left;
     DstRect.Bottom := DstY + SrcRect.Bottom - SrcRect.Top;
 

--- a/Source/GR32_Layers.pas
+++ b/Source/GR32_Layers.pas
@@ -397,7 +397,7 @@ type
 implementation
 
 uses
-  TypInfo, GR32_Image, GR32_LowLevel, GR32_Resamplers, GR32_RepaintOpt;
+  TypInfo, GR32_Image, GR32_LowLevel, GR32_Resamplers, GR32_RepaintOpt, Types;
 
 { mouse state mapping }
 const
@@ -1227,8 +1227,8 @@ begin
   if Bitmap.Empty then Exit;
   DstRect := MakeRect(GetAdjustedRect(FLocation));
   ClipRect := Buffer.ClipRect;
-  IntersectRect(TempRect, ClipRect, DstRect);
-  if IsRectEmpty(TempRect) then Exit;
+  GR32.IntersectRect(TempRect, ClipRect, DstRect);
+  if GR32.IsRectEmpty(TempRect) then Exit;
 
   SrcRect := MakeRect(0, 0, Bitmap.Width, Bitmap.Height);
   if Cropped and (LayerCollection.FOwner is TCustomImage32) and
@@ -1241,7 +1241,7 @@ begin
     end;
     if (LayerWidth < 0.5) or (LayerHeight < 0.5) then Exit;
     ImageRect := TCustomImage32(LayerCollection.FOwner).GetBitmapRect;
-    IntersectRect(ClipRect, ClipRect, ImageRect);
+    GR32.IntersectRect(ClipRect, ClipRect, ImageRect);
   end;
   StretchTransfer(Buffer, DstRect, ClipRect, FBitmap, SrcRect,
     FBitmap.Resampler, FBitmap.DrawMode, FBitmap.OnPixelCombine);
@@ -1376,7 +1376,7 @@ begin
   else if db and dx and dh_sides and not(rhNotBottomSide in FHandles) then Result := dsSizeB
   else if dl and dy and dh_sides and not(rhNotLeftSide in FHandles) then Result := dsSizeL
   else if dt and dx and dh_sides and not(rhNotTopSide in FHandles) then Result := dsSizeT
-  else if dh_center and PtInRect(R, Point(X, Y)) then Result := dsMove;
+  else if dh_center and GR32.PtInRect(R, GR32.Point(X, Y)) then Result := dsMove;
 end;
 
 procedure TRubberbandLayer.MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Integer);

--- a/Source/GR32_RepaintOpt.pas
+++ b/Source/GR32_RepaintOpt.pas
@@ -41,7 +41,7 @@ uses
 {$IFDEF FPC}
   LCLIntf,
 {$ELSE}
-  Windows,
+  Types, Windows,
 {$ENDIF}
   Classes, SysUtils, GR32, GR32_Containers, GR32_Layers;
 

--- a/Source/GR32_VectorUtils.pas
+++ b/Source/GR32_VectorUtils.pas
@@ -39,7 +39,7 @@ interface
 {$BOOLEVAL OFF}
 
 uses
-  GR32, GR32_Transforms, GR32_Polygons{$IFDEF FPC}, Types{$ENDIF};
+  Math, GR32, GR32_Transforms, GR32_Polygons{$IFDEF FPC}, Types{$ENDIF};
 
 const
   DEFAULT_MITER_LIMIT = 4.0;
@@ -218,7 +218,7 @@ function FloatPointToFixedPoint(const Points: TArrayOfArrayOfFloatPoint): TArray
 implementation
 
 uses
-  Math, SysUtils, GR32_Math, GR32_Geometry, GR32_LowLevel;
+  SysUtils, GR32_Math, GR32_Geometry, GR32_LowLevel;
 
 type
   TTransformationAccess = class(TTransformation);


### PR DESCRIPTION
…ed because unit '%s' is not specified in USES list"

Is it ok to just include the units this warning complains about, or are they missing intentionally?