### PR TITLE
LCL GTK Backend: ready for paintOptimizer mode

### DIFF
--- a/Source/GR32.pas
+++ b/Source/GR32.pas
@@ -6311,13 +6311,21 @@ begin
   if SaveTopDown then
   begin
     for i := 0 to Width*Height-1 do
+      {$ifndef fpc}
       Stream.WriteData(SwapRedBlue(Bits[i]));
+      {$else}
+      Stream.WriteDWord(SwapRedBlue(Bits[i]));
+      {$endif}
   end
   else
   begin
     for i := Height - 1 downto 0 do
       for W := 0 to Width-1 do
+        {$ifndef fpc}
         Stream.WriteData(SwapRedBlue(ScanLine[i][W]));
+        {$else}
+        Stream.WriteDWord(SwapRedBlue(ScanLine[i][W]));
+        {$endif}
   end;
 {$ENDIF RGBA_FORMAT}
 end;


### PR DESCRIPTION
I just made a version of `DoPaint` that supports AInvalidRects.count > 1.
I think it is required by reapaintOptimizer to work properly.

Sadly, even in Sprites Demo with repaintOptimizer checked, the `AInvalidRects.Count = 0`.
I mean, there is bug that prevent partial drawing buffer to form/TImage32's canvas.
but that maybe is another bug.

My Motivation is because in linux/GTK2 the graphics32 is poor in performance, we should try something to improve the repaint speed.
Bytheway, I found that GR32 RenderText is the one known as bottle neck, 
but without any touch to canvas's methods, pure `Bits` manipulation still noted slow.


-----------
![image](https://user-images.githubusercontent.com/1678529/178533992-93a908db-f15a-40fc-b759-6527609fb298.png)

Another fun fact that I found is, running Delphi ontop Wine (PlayOnLinux.Wine) giving very fast animation (by Sprites Demo).
```
Delphi + Wine: ~300+ fps
Lazarus LCL_GTK: < ~100 fps
```