### PR TITLE
Minor bug fixes for BuildDashedLine

### DIFF
--- a/Source/GR32_VectorUtils.pas
+++ b/Source/GR32_VectorUtils.pas
@@ -2092,7 +2092,7 @@ begin
   DashOffset := Wrap(DashOffset, V);
 
   DashOffset := DashOffset - V;
-  while DashOffset < 0 do
+  while (DashIndex+1 < Length(DashArray)) and (DashOffset < 0) do
   begin
     Inc(DashIndex);
     DashOffset := DashOffset + DashArray[DashIndex];

--- a/Source/GR32_VectorUtils.pas
+++ b/Source/GR32_VectorUtils.pas
@@ -2112,7 +2112,7 @@ begin
     AddDash(0);
     len1 := Length(Result[0]);
     len2 := Length(Result[J]);
-    if (len1 > 0) and (len2 > 0) then
+    if (len1 > 0) and (len2 > 0) and (Result[0][0]=Result[J][len2 - 1]) then
     begin
       SetLength(Result[0], len1 + len2 -1);
       Move(Result[0][0], Result[0][len2 - 1], SizeOf(TFloatPoint) * len1);

--- a/Source/GR32_VectorUtils.pas
+++ b/Source/GR32_VectorUtils.pas
@@ -2092,7 +2092,7 @@ begin
   DashOffset := Wrap(DashOffset, V);
 
   DashOffset := DashOffset - V;
-  while (DashIndex+1 < Length(DashArray)) and (DashOffset < 0) do
+  while (DashOffset < 0) and (DashIndex < High(DashArray)) do
   begin
     Inc(DashIndex);
     DashOffset := DashOffset + DashArray[DashIndex];
@@ -2112,7 +2112,8 @@ begin
     AddDash(0);
     len1 := Length(Result[0]);
     len2 := Length(Result[J]);
-    if (len1 > 0) and (len2 > 0) and (Result[0][0]=Result[J][len2 - 1]) then
+    // Only merge if the first and last points are contributing on a dash
+    if (len1 > 0) and (len2 > 0) and (Result[0][0] = Result[J][len2 - 1]) then
     begin
       SetLength(Result[0], len1 + len2 -1);
       Move(Result[0][0], Result[0][len2 - 1], SizeOf(TFloatPoint) * len1);


### PR DESCRIPTION
 **Bounds check added for DashArray** 
bug code
```
           SetLength(Dashes,3);
           Dashes[0] := 21.4456520080566;
           Dashes[1] := 21.4456520080566;
           Dashes[2] := 21.4456520080566;
           BuildDashedLine(Points,Dashes);
```
original code 
```
  while DashOffset < 0 do
  begin
    Inc(DashIndex);
    DashOffset := DashOffset + DashArray[DashIndex];
  end;
```
On entering the loop, DashOffset has a negative value of the sum of the dash lengths,  so due to the floating point precision loss DashOffset sometimes wont reach absolute zero to leave the loop.



 **Incorrect dashs merge** 
 
![dasherr](https://user-images.githubusercontent.com/40634105/192286483-8d0b4723-15e3-465c-b4b2-327a0b985048.png)

