### PR TITLE
Add "System.Win" to unit scopes under project settings

### DIFF
--- a/Source/Packages/D110/GR32_R.dproj
+++ b/Source/Packages/D110/GR32_R.dproj
@@ -50,7 +50,7 @@
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DCC_E>false</DCC_E>
         <SanitizedProjectName>GR32_R</SanitizedProjectName>
-        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
         <DCC_F>false</DCC_F>
         <DCC_ImageBase>00400000</DCC_ImageBase>
         <RuntimeOnlyPackage>true</RuntimeOnlyPackage>


### PR DESCRIPTION
This addition is to the run-time package only as the design-time already has this scope added. It will solve to find the "ComObj" unit.