### PR TITLE
[x86_64 / Bug Fix] Improvement and bug fixes to DivMod assembly

### DIFF
--- a/Source/GR32_Math.pas
+++ b/Source/GR32_Math.pas
@@ -1667,11 +1667,19 @@ asm
         MOV     DWORD PTR [ECX], edx
 {$ENDIF}
 {$IFDEF TARGET_x64}
-        MOV     RAX, RCX
-        MOV     R9, RDX
+  {$IFDEF MSWINDOWS}
+        MOV     EAX, ECX
+        MOV     ECX, EDX
         CDQ
-        IDIV    R9
-        MOV     DWORD PTR [R8], EDX
+        IDIV    ECX
+        MOV     [R8],EDX
+  {$ELSE}
+        MOV     EAX, EDI
+        MOV     RDI, RDX
+        CDQ
+        IDIV    ESI
+        MOV     [RDI],EDX
+  {$ENDIF}
 {$ENDIF}
 {$ENDIF}
 end;


### PR DESCRIPTION
This pull request improves the speed of the x64 assembly version of DivMod, and adds a System V ABI (non-Windows) version.  The main points to note:

- The original version mixed 64-bit and 32-bit operands, resulting in a slower 64-bit division but also potentially causing unpredictable results by calling CDQ, which works on the 32-bit registers.
- Reduced the number of registers the algorithm uses, which won't cause any difference in this isolated function but may prove useful if it is copied later and mixed with another operation.
- A System V ABI version of the algorithm now exists, where the parameters are passed through RDI, RSI and RDX respectively.