### PR TITLE
GR32_Math refactoring

### DIFF
--- a/Source/GR32.Blend.SSE2.pas
+++ b/Source/GR32.Blend.SSE2.pas
@@ -1522,7 +1522,7 @@ asm
   db $00, $04, $08, $0C
 end;
 
-procedure CombineMem_SSE41_Kadaif(F: TColor32; var B: TColor32; W: Cardinal); {$IFDEF FPC} assembler; {$IFDEF TARGET_X64}nostackframe;{$ENDIF} {$ENDIF}
+procedure CombineMem_SSE41_Kadaif(F: TColor32; var B: TColor32; W: Cardinal); {$IFDEF FPC} assembler; nostackframe; {$ENDIF}
 (*
 Contributed by: Kadaif
 

--- a/Source/GR32.Blend.SSE2.pas
+++ b/Source/GR32.Blend.SSE2.pas
@@ -1522,7 +1522,7 @@ asm
   db $00, $04, $08, $0C
 end;
 
-procedure CombineMem_SSE41_Kadaif(F: TColor32; var B: TColor32; W: Cardinal); {$IFDEF FPC} assembler; nostackframe; {$ENDIF}
+procedure CombineMem_SSE41_Kadaif(F: TColor32; var B: TColor32; W: Cardinal); {$IFDEF FPC} assembler; {$IFDEF TARGET_X64}nostackframe;{$ENDIF} {$ENDIF}
 (*
 Contributed by: Kadaif
 
@@ -1597,21 +1597,21 @@ asm
         PMULLD    XMM2, XMM0                    // XMM2 <- (ColorX - ColorY) * Weight * $8081
 
         // Add bias (~$7F*$8081)
-{$ifndef FPC}
+{$if (not defined(FPC)) or (not defined(TARGET_X64))}
         PADDD     XMM2, DQWORD PTR [SIMD_4x003FFF7F] // XMM2 <- ((ColorX - ColorY) * Weight * $8081) + Bias
 {$else}
         PADDD     XMM2, DQWORD PTR [rip+SIMD_4x003FFF7F]
-{$endif}
+{$ifend}
 
         // Reduce 32-bits to 9-bits
         PSRLD     XMM2, 23                      // XMM2 <- (((ColorX - ColorY) * Weight * $8081) + Bias) shr 23
 
         // Convert from dwords to bytes with truncation (losing the sign in the 9th bit)
-{$ifndef FPC}
+{$if (not defined(FPC)) or (not defined(TARGET_X64))}
         PSHUFB    XMM2, DQWORD PTR [SIMD_4x0C080400] // XMM2[0] <- XMM4[0..3][0]
 {$else}
         PSHUFB    XMM2, DQWORD PTR [rip+SIMD_4x0C080400]
-{$endif}
+{$ifend}
 
         // Result := Value + ColorY
         PADDB     XMM2, XMM1                    // XMM2 <- XMM2 + ColorY

--- a/Source/GR32_LowLevel.pas
+++ b/Source/GR32_LowLevel.pas
@@ -1466,7 +1466,7 @@ end;
 //------------------------------------------------------------------------------
 // FastRound_SSE41
 //------------------------------------------------------------------------------
-function FastRound_SSE41(Value: TFloat): Integer; {$IFDEF FPC}assembler; nostackframe;{$ENDIF}
+function FastRound_SSE41(Value: TFloat): Integer; {$IFDEF FPC} assembler; {$IFDEF TARGET_X64} nostackframe; {$ENDIF}{$ENDIF}
 asm
 {$if defined(TARGET_x86)}
         MOVSS   xmm0, Value
@@ -1503,7 +1503,7 @@ end;
 // Faster that RTL Trunc on x86 and x64
 //
 {$IFNDEF OMIT_SSE2}
-function FastTrunc_SSE2(Value: TFloat): Integer; {$IFDEF FPC}assembler; nostackframe;{$ENDIF}
+function FastTrunc_SSE2(Value: TFloat): Integer; {$IFDEF FPC} assembler; {$IFDEF TARGET_X64} nostackframe; {$ENDIF}{$ENDIF}
 asm
 {$if defined(TARGET_x86)}
         MOVSS      XMM0, Value
@@ -1520,7 +1520,7 @@ end;
 // Faster that RTL Trunc on x64 (and sometimes on x86).
 //
 {$IFNDEF OMIT_SSE2}
-function SlowTrunc_SSE2(Value: TFloat): Integer;
+function SlowTrunc_SSE2(Value: TFloat): Integer; {$IFDEF FPC} assembler; {$ENDIF}
 var
   SaveMXCSR: Cardinal;
   NewMXCSR: Cardinal;
@@ -1570,7 +1570,7 @@ end;
 // Faster that RTL Trunc on x86
 //
 {$IFNDEF OMIT_SSE2}
-function FastTrunc_SSE41(Value: TFloat): Integer; {$IFDEF FPC}assembler; nostackframe;{$ENDIF}
+function FastTrunc_SSE41(Value: TFloat): Integer; {$IFDEF FPC} assembler; {$IFDEF TARGET_X64} nostackframe; {$ENDIF}{$ENDIF}
 asm
 {$if defined(TARGET_x86)}
         MOVSS   xmm0, Value

--- a/Source/GR32_Math.pas
+++ b/Source/GR32_Math.pas
@@ -243,27 +243,6 @@ const
 
 
 //------------------------------------------------------------------------------
-
-{$if defined(FPC) and defined(TARGET_X64)}
-// TODO : Why do we need these?
-function Ceil(X: Single): Integer;
-begin
-  Result := Trunc(X);
-  if (X - Result) > 0 then
-    Inc(Result);
-end;
-
-function Floor(X: Single): Integer;
-begin
-  Result := Trunc(X);
-  if (X - Result) < 0 then
-    Dec(Result);
-end;
-{$ifend}
-
-
-
-//------------------------------------------------------------------------------
 //
 //      Fixed-point math
 //

--- a/Source/GR32_Math_FPC.pas
+++ b/Source/GR32_Math_FPC.pas
@@ -36,8 +36,11 @@ unit GR32_Math_FPC;
 
 interface
 
-{$IFDEF FPC}
-{$IFDEF TARGET_X64}
+{$I GR32.inc}
+
+// TODO : This block was never enabled as TARGET_X64 isn't defined unless GR32.inc is included
+// The block has now been disabled as we can't {$mode objfpc} this late.
+{$if False and defined(FPC) and defined(TARGET_X64)}
 {$mode objfpc}
 
 (*
@@ -57,12 +60,39 @@ function Round(D: Single): Int64; [internproc: fpc_in_round_real];
 function Frac(D: Single): Single; [internproc: fpc_in_frac_real];
 function Int(D: Single): Single; [internproc: fpc_in_int_real];
 function Trunc(D: Single): Int64; [internproc: fpc_in_trunc_real];
+{$ifend}
 
+//------------------------------------------------------------------------------
+
+{$if defined(FPC) and defined(TARGET_X64)}
 function Ceil(X: Single): Integer; {$IFDEF USEINLINING} inline; {$ENDIF}
 function Floor(X: Single): Integer; {$IFDEF USEINLINING} inline; {$ENDIF}
-{$ENDIF}
-{$ENDIF}
+{$ifend}
+
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 implementation
+
+//------------------------------------------------------------------------------
+
+{$if defined(FPC) and defined(TARGET_X64)}
+function Ceil(X: Single): Integer;
+begin
+  Result := Trunc(X);
+  if (X - Result) > 0 then
+    Inc(Result);
+end;
+
+function Floor(X: Single): Integer;
+begin
+  Result := Trunc(X);
+  if (X - Result) < 0 then
+    Dec(Result);
+end;
+{$ifend}
+
+//------------------------------------------------------------------------------
 
 end.


### PR DESCRIPTION
@CuriousKit
As we discussed elsewhere, this is how I envisioned the separation of the PUREPASCAL and the various asm implementations.

It is mainly an attempt to avoid having to extract the different implementation types into separate include files.

Additionally I have fixed a bunch of "nostackframe" directives as discussed in PR #289.

