### PR TITLE
Changes to the Bindings property on TFunctionRegistry (and related units) to fix incompatibility with C++Builder

### DIFF
--- a/Source/GR32.Blend.Assembler.pas
+++ b/Source/GR32.Blend.Assembler.pas
@@ -1426,18 +1426,18 @@ end;
 {$IFNDEF PUREPASCAL}
 procedure RegisterBindingFunctions;
 begin
-  BlendRegistry[FID_COMBINEREG].Add(    @CombineReg_ASM,        [isAssembler]).Name := 'CombineReg_ASM';
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_ASM,        [isAssembler]).Name := 'CombineMem_ASM';
-  BlendRegistry[FID_BLENDREG].Add(      @BlendReg_ASM,          [isAssembler]).Name := 'BlendReg_ASM';
-  BlendRegistry[FID_BLENDMEM].Add(      @BlendMem_ASM,          [isAssembler]).Name := 'BlendMem_ASM';
-  BlendRegistry[FID_BLENDMEMS].Add(     @BlendMems_ASM,         [isAssembler]).Name := 'BlendMems_ASM';
-  BlendRegistry[FID_BLENDREGEX].Add(    @BlendRegEx_ASM,        [isAssembler]).Name := 'BlendRegEx_ASM';
+  BlendRegistry.BindingsByID[FID_COMBINEREG].Add(    @CombineReg_ASM,        [isAssembler]).Name := 'CombineReg_ASM';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_ASM,        [isAssembler]).Name := 'CombineMem_ASM';
+  BlendRegistry.BindingsByID[FID_BLENDREG].Add(      @BlendReg_ASM,          [isAssembler]).Name := 'BlendReg_ASM';
+  BlendRegistry.BindingsByID[FID_BLENDMEM].Add(      @BlendMem_ASM,          [isAssembler]).Name := 'BlendMem_ASM';
+  BlendRegistry.BindingsByID[FID_BLENDMEMS].Add(     @BlendMems_ASM,         [isAssembler]).Name := 'BlendMems_ASM';
+  BlendRegistry.BindingsByID[FID_BLENDREGEX].Add(    @BlendRegEx_ASM,        [isAssembler]).Name := 'BlendRegEx_ASM';
 {$IFDEF TARGET_X86}
-  BlendRegistry[FID_BLENDMEMEX].Add(    @BlendMemEx_ASM,        [isAssembler]).Name := 'BlendMemEx_ASM'; // Implemented on x64 but broken
+  BlendRegistry.BindingsByID[FID_BLENDMEMEX].Add(    @BlendMemEx_ASM,        [isAssembler]).Name := 'BlendMemEx_ASM'; // Implemented on x64 but broken
 {$ENDIF}
-  BlendRegistry[FID_BLENDLINE].Add(     @BlendLine_ASM,         [isAssembler]).Name := 'BlendLine_ASM';
+  BlendRegistry.BindingsByID[FID_BLENDLINE].Add(     @BlendLine_ASM,         [isAssembler]).Name := 'BlendLine_ASM';
 {$IFNDEF TARGET_x64}
-  BlendRegistry[FID_MERGEREG].Add(      @MergeReg_ASM,          [isAssembler]).Name := 'MergeReg_ASM';
+  BlendRegistry.BindingsByID[FID_MERGEREG].Add(      @MergeReg_ASM,          [isAssembler]).Name := 'MergeReg_ASM';
 {$ENDIF}
 end;
 {$ENDIF}

--- a/Source/GR32.Blend.Pascal.pas
+++ b/Source/GR32.Blend.Pascal.pas
@@ -1084,51 +1084,51 @@ end;
 procedure RegisterBindingFunctions;
 begin
   // pure pascal
-  BlendRegistry[FID_MERGEREG].Add(      @MergeReg_Pas,          [isPascal]).Name := 'MergeReg_Pas';
-  BlendRegistry[FID_MERGEMEM].Add(      @MergeMem_Pas,          [isPascal]).Name := 'MergeMem_Pas';
-  BlendRegistry[FID_MERGEMEMS].Add(     @MergeMems_Pas,         [isPascal]).Name := 'MergeMems_Pas';
-  BlendRegistry[FID_MERGEMEMEX].Add(    @MergeMemEx_Pas,        [isPascal]).Name := 'MergeMemEx_Pas';
-  BlendRegistry[FID_MERGEREGEX].Add(    @MergeRegEx_Pas,        [isPascal]).Name := 'MergeRegEx_Pas';
-  BlendRegistry[FID_MERGELINE].Add(     @MergeLine_Pas,         [isPascal]).Name := 'MergeLine_Pas';
-  BlendRegistry[FID_MERGELINEEX].Add(   @MergeLineEx_Pas,       [isPascal]).Name := 'MergeLineEx_Pas';
+  BlendRegistry.BindingsByID[FID_MERGEREG].Add(      @MergeReg_Pas,          [isPascal]).Name := 'MergeReg_Pas';
+  BlendRegistry.BindingsByID[FID_MERGEMEM].Add(      @MergeMem_Pas,          [isPascal]).Name := 'MergeMem_Pas';
+  BlendRegistry.BindingsByID[FID_MERGEMEMS].Add(     @MergeMems_Pas,         [isPascal]).Name := 'MergeMems_Pas';
+  BlendRegistry.BindingsByID[FID_MERGEMEMEX].Add(    @MergeMemEx_Pas,        [isPascal]).Name := 'MergeMemEx_Pas';
+  BlendRegistry.BindingsByID[FID_MERGEREGEX].Add(    @MergeRegEx_Pas,        [isPascal]).Name := 'MergeRegEx_Pas';
+  BlendRegistry.BindingsByID[FID_MERGELINE].Add(     @MergeLine_Pas,         [isPascal]).Name := 'MergeLine_Pas';
+  BlendRegistry.BindingsByID[FID_MERGELINEEX].Add(   @MergeLineEx_Pas,       [isPascal]).Name := 'MergeLineEx_Pas';
 
-  BlendRegistry[FID_COMBINEREG].Add(    @CombineReg_Pas,        [isPascal]).Name := 'CombineReg_Pas';
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_Pas_Retro,  [isPascal]).Name := 'CombineMem_Pas_Retro';
+  BlendRegistry.BindingsByID[FID_COMBINEREG].Add(    @CombineReg_Pas,        [isPascal]).Name := 'CombineReg_Pas';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_Pas_Retro,  [isPascal]).Name := 'CombineMem_Pas_Retro';
 {$ifdef BENCHMARK}
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_Pas_Table,  [isPascal], BindingPriorityWorse).Name := 'CombineMem_Pas_Table';
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_Pas_Div255,  [isPascal], BindingPriorityWorse).Name := 'CombineMem_Pas_Div255';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_Pas_Table,  [isPascal], BindingPriorityWorse).Name := 'CombineMem_Pas_Table';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_Pas_Div255,  [isPascal], BindingPriorityWorse).Name := 'CombineMem_Pas_Div255';
 {$endif BENCHMARK}
-  BlendRegistry[FID_COMBINELINE].Add(   @CombineLine_Pas,       [isPascal]).Name := 'CombineLine_Pas';
+  BlendRegistry.BindingsByID[FID_COMBINELINE].Add(   @CombineLine_Pas,       [isPascal]).Name := 'CombineLine_Pas';
 
-  BlendRegistry[FID_BLENDREG].Add(      @BlendReg_Pas,          [isPascal]).Name := 'BlendReg_Pas';
-  BlendRegistry[FID_BLENDMEM].Add(      @BlendMem_Pas,          [isPascal]).Name := 'BlendMem_Pas';
-  BlendRegistry[FID_BLENDMEMS].Add(     @BlendMems_Pas,         [isPascal]).Name := 'BlendMems_Pas';
-  BlendRegistry[FID_BLENDLINE].Add(     @BlendLine_Pas,         [isPascal]).Name := 'BlendLine_Pas';
-  BlendRegistry[FID_BLENDREGEX].Add(    @BlendRegEx_Pas,        [isPascal]).Name := 'BlendRegEx_Pas';
-  BlendRegistry[FID_BLENDMEMEX].Add(    @BlendMemEx_Pas,        [isPascal]).Name := 'BlendMemEx_Pas';
-  BlendRegistry[FID_BLENDLINEEX].Add(   @BlendLineEx_Pas,       [isPascal]).Name := 'BlendLineEx_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDREG].Add(      @BlendReg_Pas,          [isPascal]).Name := 'BlendReg_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDMEM].Add(      @BlendMem_Pas,          [isPascal]).Name := 'BlendMem_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDMEMS].Add(     @BlendMems_Pas,         [isPascal]).Name := 'BlendMems_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDLINE].Add(     @BlendLine_Pas,         [isPascal]).Name := 'BlendLine_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDREGEX].Add(    @BlendRegEx_Pas,        [isPascal]).Name := 'BlendRegEx_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDMEMEX].Add(    @BlendMemEx_Pas,        [isPascal]).Name := 'BlendMemEx_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDLINEEX].Add(   @BlendLineEx_Pas,       [isPascal]).Name := 'BlendLineEx_Pas';
 
-  BlendRegistry[FID_COLORDIV].Add(      @ColorDiv_Pas,          [isPascal]).Name := 'ColorDiv_Pas';
-  BlendRegistry[FID_COLORAVERAGE].Add(  @ColorAverage_Pas,      [isPascal]).Name := 'ColorAverage_Pas';
-  BlendRegistry[FID_COLORMAX].Add(      @ColorMax_Pas,          [isPascal]).Name := 'ColorMax_Pas';
-  BlendRegistry[FID_COLORMIN].Add(      @ColorMin_Pas,          [isPascal]).Name := 'ColorMin_Pas';
-  BlendRegistry[FID_COLORADD].Add(      @ColorAdd_Pas,          [isPascal]).Name := 'ColorAdd_Pas';
-  BlendRegistry[FID_COLORSUB].Add(      @ColorSub_Pas,          [isPascal]).Name := 'ColorSub_Pas';
-  BlendRegistry[FID_COLORMODULATE].Add( @ColorModulate_Pas,     [isPascal]).Name := 'ColorModulate_Pas';
-  BlendRegistry[FID_COLORDIFFERENCE].Add(@ColorDifference_Pas,  [isPascal]).Name := 'ColorDifference_Pas';
-  BlendRegistry[FID_COLOREXCLUSION].Add(@ColorExclusion_Pas,    [isPascal]).Name := 'ColorExclusion_Pas';
-  BlendRegistry[FID_COLORSCALE].Add(    @ColorScale_Pas,        [isPascal]).Name := 'ColorScale_Pas';
-  BlendRegistry[FID_COLORSCREEN].Add(   @ColorScreen_Pas,       [isPascal]).Name := 'ColorScreen_Pas';
-  BlendRegistry[FID_COLORDODGE].Add(    @ColorDodge_Pas,        [isPascal]).Name := 'ColorDodge_Pas';
-  BlendRegistry[FID_COLORBURN].Add(     @ColorBurn_Pas,         [isPascal]).Name := 'ColorBurn_Pas';
+  BlendRegistry.BindingsByID[FID_COLORDIV].Add(      @ColorDiv_Pas,          [isPascal]).Name := 'ColorDiv_Pas';
+  BlendRegistry.BindingsByID[FID_COLORAVERAGE].Add(  @ColorAverage_Pas,      [isPascal]).Name := 'ColorAverage_Pas';
+  BlendRegistry.BindingsByID[FID_COLORMAX].Add(      @ColorMax_Pas,          [isPascal]).Name := 'ColorMax_Pas';
+  BlendRegistry.BindingsByID[FID_COLORMIN].Add(      @ColorMin_Pas,          [isPascal]).Name := 'ColorMin_Pas';
+  BlendRegistry.BindingsByID[FID_COLORADD].Add(      @ColorAdd_Pas,          [isPascal]).Name := 'ColorAdd_Pas';
+  BlendRegistry.BindingsByID[FID_COLORSUB].Add(      @ColorSub_Pas,          [isPascal]).Name := 'ColorSub_Pas';
+  BlendRegistry.BindingsByID[FID_COLORMODULATE].Add( @ColorModulate_Pas,     [isPascal]).Name := 'ColorModulate_Pas';
+  BlendRegistry.BindingsByID[FID_COLORDIFFERENCE].Add(@ColorDifference_Pas,  [isPascal]).Name := 'ColorDifference_Pas';
+  BlendRegistry.BindingsByID[FID_COLOREXCLUSION].Add(@ColorExclusion_Pas,    [isPascal]).Name := 'ColorExclusion_Pas';
+  BlendRegistry.BindingsByID[FID_COLORSCALE].Add(    @ColorScale_Pas,        [isPascal]).Name := 'ColorScale_Pas';
+  BlendRegistry.BindingsByID[FID_COLORSCREEN].Add(   @ColorScreen_Pas,       [isPascal]).Name := 'ColorScreen_Pas';
+  BlendRegistry.BindingsByID[FID_COLORDODGE].Add(    @ColorDodge_Pas,        [isPascal]).Name := 'ColorDodge_Pas';
+  BlendRegistry.BindingsByID[FID_COLORBURN].Add(     @ColorBurn_Pas,         [isPascal]).Name := 'ColorBurn_Pas';
 
-  BlendRegistry[FID_BLENDCOLORADD].Add( @BlendColorAdd_Pas,     [isPascal]).Name := 'BlendColorAdd_Pas';
-  BlendRegistry[FID_BLENDCOLORMODULATE].Add(@BlendColorModulate_Pas, [isPascal]).Name := 'BlendColorModulate_Pas';
-  BlendRegistry[FID_BLENDREGRGB].Add(   @BlendRegRGB_Pas,       [isPascal]).Name := 'BlendRegRGB_Pas';
-  BlendRegistry[FID_BLENDMEMRGB].Add(   @BlendMemRGB_Pas,       [isPascal]).Name := 'BlendMemRGB_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDCOLORADD].Add( @BlendColorAdd_Pas,     [isPascal]).Name := 'BlendColorAdd_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDCOLORMODULATE].Add(@BlendColorModulate_Pas, [isPascal]).Name := 'BlendColorModulate_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDREGRGB].Add(   @BlendRegRGB_Pas,       [isPascal]).Name := 'BlendRegRGB_Pas';
+  BlendRegistry.BindingsByID[FID_BLENDMEMRGB].Add(   @BlendMemRGB_Pas,       [isPascal]).Name := 'BlendMemRGB_Pas';
 
-  BlendRegistry[FID_LIGHTEN].Add(       @LightenReg_Pas,        [isPascal]).Name := 'LightenReg_Pas';
-  BlendRegistry[@@ScaleMems].Add(       @ScaleMems_Pas,         [isPascal]).Name := 'ScaleMems_Pas';
+  BlendRegistry.BindingsByID[FID_LIGHTEN].Add(       @LightenReg_Pas,        [isPascal]).Name := 'LightenReg_Pas';
+  BlendRegistry.Bindings[@@ScaleMems].Add(           @ScaleMems_Pas,         [isPascal]).Name := 'ScaleMems_Pas';
 end;
 
 //------------------------------------------------------------------------------

--- a/Source/GR32.Blend.SSE2.pas
+++ b/Source/GR32.Blend.SSE2.pas
@@ -2633,46 +2633,46 @@ procedure RegisterBindingFunctions;
 begin
 {$IFNDEF OMIT_SSE2}
 
-  BlendRegistry[FID_MERGEREG].Add(      @MergeReg_SSE2,         [isSSE2]).Name := 'MergeReg_SSE2';
-  BlendRegistry[FID_COMBINEREG].Add(    @CombineReg_SSE2,       [isSSE2]).Name := 'CombineReg_SSE2';
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_SSE2_128,   [isSSE2]).Name := 'CombineMem_SSE2_128';
+  BlendRegistry.BindingsByID[FID_MERGEREG].Add(      @MergeReg_SSE2,         [isSSE2]).Name := 'MergeReg_SSE2';
+  BlendRegistry.BindingsByID[FID_COMBINEREG].Add(    @CombineReg_SSE2,       [isSSE2]).Name := 'CombineReg_SSE2';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_SSE2_128,   [isSSE2]).Name := 'CombineMem_SSE2_128';
 {$ifndef FPC} // CombineMem_SSE41_Kadaif is currently broken on FPC
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_SSE41_Kadaif, [isSSE41]).Name := 'CombineMem_SSE41_Kadaif';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_SSE41_Kadaif, [isSSE41]).Name := 'CombineMem_SSE41_Kadaif';
 {$else}
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_SSE41_8081, [isSSE41]).Name := 'CombineMem_SSE41_8081';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_SSE41_8081, [isSSE41]).Name := 'CombineMem_SSE41_8081';
 {$endif}
 {$ifdef BENCHMARK}
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_SSE2_Table, [isSSE2], BindingPriorityWorse).Name := 'CombineMem_SSE2_Table';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_SSE2_Table, [isSSE2], BindingPriorityWorse).Name := 'CombineMem_SSE2_Table';
 {$ifndef FPC}
-  BlendRegistry[FID_COMBINEMEM].Add(    @CombineMem_SSE41_8081, [isSSE41], BindingPriorityWorse).Name := 'CombineMem_SSE41_8081';
+  BlendRegistry.BindingsByID[FID_COMBINEMEM].Add(    @CombineMem_SSE41_8081, [isSSE41], BindingPriorityWorse).Name := 'CombineMem_SSE41_8081';
 {$endif}
 {$endif}
-  BlendRegistry[FID_COMBINELINE].Add(   @CombineLine_SSE2,      [isSSE2]).Name := 'CombineLine_SSE2';
-  BlendRegistry[FID_BLENDREG].Add(      @BlendReg_SSE2,         [isSSE2]).Name := 'BlendReg_SSE2';
-  BlendRegistry[FID_BLENDMEM].Add(      @BlendMem_SSE2,         [isSSE2]).Name := 'BlendMem_SSE2';
-  BlendRegistry[FID_BLENDMEMS].Add(     @BlendMems_SSE2,        [isSSE2]).Name := 'BlendMems_SSE2';
-  BlendRegistry[FID_BLENDMEMEX].Add(    @BlendMemEx_SSE2,       [isSSE2]).Name := 'BlendMemEx_SSE2';
-  BlendRegistry[FID_BLENDLINE].Add(     @BlendLine_SSE2,        [isSSE2]).Name := 'BlendLine_SSE2';
-  BlendRegistry[FID_BLENDLINEEX].Add(   @BlendLineEx_SSE2,      [isSSE2]).Name := 'BlendLineEx_SSE2';
-  BlendRegistry[FID_BLENDREGEX].Add(    @BlendRegEx_SSE2,       [isSSE2]).Name := 'BlendRegEx_SSE2';
-  BlendRegistry[FID_COLORMAX].Add(      @ColorMax_SSE2,         [isSSE2]).Name := 'ColorMax_SSE2';
-  BlendRegistry[FID_COLORMIN].Add(      @ColorMin_SSE2,         [isSSE2]).Name := 'ColorMin_SSE2';
-  BlendRegistry[FID_COLORADD].Add(      @ColorAdd_SSE2,         [isSSE2]).Name := 'ColorAdd_SSE2';
-  BlendRegistry[FID_COLORSUB].Add(      @ColorSub_SSE2,         [isSSE2]).Name := 'ColorSub_SSE2';
-  BlendRegistry[FID_COLORMODULATE].Add( @ColorModulate_SSE2,    [isSSE2]).Name := 'ColorModulate_SSE2';
-  BlendRegistry[FID_COLORDIFFERENCE].Add(@ColorDifference_SSE2,  [isSSE2]).Name := 'ColorDifference_SSE2';
-  BlendRegistry[FID_COLOREXCLUSION].Add(@ColorExclusion_SSE2,   [isSSE2]).Name := 'ColorExclusion_SSE2';
-  BlendRegistry[FID_COLORSCALE].Add(    @ColorScale_SSE2,       [isSSE2]).Name := 'ColorScale_SSE2';
-  BlendRegistry[FID_LIGHTEN].Add(       @LightenReg_SSE2,       [isSSE]).Name := 'LightenReg_SSE2';
-  BlendRegistry[FID_BLENDREGRGB].Add(   @BlendRegRGB_SSE2,      [isSSE2]).Name := 'BlendRegRGB_SSE2';
-  BlendRegistry[FID_BLENDMEMRGB].Add(   @BlendMemRGB_SSE2,      [isSSE2]).Name := 'BlendMemRGB_SSE2';
+  BlendRegistry.BindingsByID[FID_COMBINELINE].Add(   @CombineLine_SSE2,      [isSSE2]).Name := 'CombineLine_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDREG].Add(      @BlendReg_SSE2,         [isSSE2]).Name := 'BlendReg_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDMEM].Add(      @BlendMem_SSE2,         [isSSE2]).Name := 'BlendMem_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDMEMS].Add(     @BlendMems_SSE2,        [isSSE2]).Name := 'BlendMems_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDMEMEX].Add(    @BlendMemEx_SSE2,       [isSSE2]).Name := 'BlendMemEx_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDLINE].Add(     @BlendLine_SSE2,        [isSSE2]).Name := 'BlendLine_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDLINEEX].Add(   @BlendLineEx_SSE2,      [isSSE2]).Name := 'BlendLineEx_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDREGEX].Add(    @BlendRegEx_SSE2,       [isSSE2]).Name := 'BlendRegEx_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORMAX].Add(      @ColorMax_SSE2,         [isSSE2]).Name := 'ColorMax_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORMIN].Add(      @ColorMin_SSE2,         [isSSE2]).Name := 'ColorMin_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORADD].Add(      @ColorAdd_SSE2,         [isSSE2]).Name := 'ColorAdd_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORSUB].Add(      @ColorSub_SSE2,         [isSSE2]).Name := 'ColorSub_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORMODULATE].Add( @ColorModulate_SSE2,    [isSSE2]).Name := 'ColorModulate_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORDIFFERENCE].Add(@ColorDifference_SSE2,  [isSSE2]).Name := 'ColorDifference_SSE2';
+  BlendRegistry.BindingsByID[FID_COLOREXCLUSION].Add(@ColorExclusion_SSE2,   [isSSE2]).Name := 'ColorExclusion_SSE2';
+  BlendRegistry.BindingsByID[FID_COLORSCALE].Add(    @ColorScale_SSE2,       [isSSE2]).Name := 'ColorScale_SSE2';
+  BlendRegistry.BindingsByID[FID_LIGHTEN].Add(       @LightenReg_SSE2,       [isSSE]).Name := 'LightenReg_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDREGRGB].Add(   @BlendRegRGB_SSE2,      [isSSE2]).Name := 'BlendRegRGB_SSE2';
+  BlendRegistry.BindingsByID[FID_BLENDMEMRGB].Add(   @BlendMemRGB_SSE2,      [isSSE2]).Name := 'BlendMemRGB_SSE2';
 {$ifdef GR32_SCALEMEMS_FAST}
-  BlendRegistry[@@ScaleMems].Add(       @FastScaleMems_SSE41,[isSSE41]).Name := 'FastScaleMems_SSE41';
+  BlendRegistry.Bindings[@@ScaleMems].Add(           @FastScaleMems_SSE41,[isSSE41]).Name := 'FastScaleMems_SSE41';
 {$else}
-  BlendRegistry[@@ScaleMems].Add(       @ScaleMems_SSE41,    [isSSE41]).Name := 'ScaleMems_SSE41';
+  BlendRegistry.Bindings[@@ScaleMems].Add(           @ScaleMems_SSE41,    [isSSE41]).Name := 'ScaleMems_SSE41';
 {$endif}
 {$IFDEF TEST_BLENDMEMRGB128SSE4}
-  BlendRegistry[FID_BLENDMEMRGB128].Add(@BlendMemRGB128_SSE4,   [isSSE2]).Name := 'BlendMemRGB128_SSE4';
+  BlendRegistry.BindingsByID[FID_BLENDMEMRGB128].Add(@BlendMemRGB128_SSE4,   [isSSE2]).Name := 'BlendMemRGB128_SSE4';
 {$ENDIF}
 
 {$ENDIF}

--- a/Source/GR32_Bindings.pas
+++ b/Source/GR32_Bindings.pas
@@ -258,9 +258,9 @@ type
     function FindBinding(BindVariable: PPointer): IBindingInfo; overload;
     function FindBinding(FunctionID: NativeInt): IBindingInfo; overload;
 
-    property Bindings[const Name: string]: IBindingInfo read GetBinding; default;
     property Bindings[BindVariable: PPointer]: IBindingInfo read GetBinding; default;
-    property Bindings[FunctionID: NativeInt]: IBindingInfo read GetBinding; default;
+    property BindingsByName[const Name: string]: IBindingInfo read GetBinding;
+    property BindingsByID[FunctionID: NativeInt]: IBindingInfo read GetBinding;
 
     // List of bindings in this registry.
     function GetEnumerator: TEnumerator<IBindingInfo>;
@@ -703,7 +703,7 @@ function TFunctionRegistry.Add(FunctionID: NativeInt; Proc: Pointer; Instruction
 var
   BindingInfo: IBindingInfo;
 begin
-  BindingInfo := Bindings[FunctionID];
+  BindingInfo := BindingsByID[FunctionID];
 
   Result := BindingInfo.Add(Proc, InstructionSupport, Priority);
   Result.Flags := Flags;
@@ -740,7 +740,7 @@ end;
 
 function TFunctionRegistry.FindFunction(FunctionID: NativeInt; PriorityCallback: TFunctionPriority): Pointer;
 begin
-  Result := Bindings[FunctionID].FindFunction(PriorityCallback);
+  Result := BindingsByID[FunctionID].FindFunction(PriorityCallback);
 end;
 
 //------------------------------------------------------------------------------
@@ -850,7 +850,7 @@ end;
 
 function TFunctionRegistry.Rebind(FunctionID: NativeInt; PriorityCallback: TFunctionPriority): boolean;
 begin
-  Result := Bindings[FunctionID].Rebind(PriorityCallback);
+  Result := BindingsByID[FunctionID].Rebind(PriorityCallback);
 end;
 
 //------------------------------------------------------------------------------

--- a/Source/GR32_ColorGradients.pas
+++ b/Source/GR32_ColorGradients.pas
@@ -5156,13 +5156,13 @@ begin
   GradientRegistry.RegisterBinding(FID_LINEAR4, @@Linear4PointInterpolationProc, 'Linear4PointInterpolationProc');
 
   // pure pascal
-  GradientRegistry[FID_LINEAR3].Add(@Linear3PointInterpolation_Pas, [isPascal]).name := 'Linear3PointInterpolation_Pas';
-  GradientRegistry[FID_LINEAR4].Add(@Linear4PointInterpolation_Pas, [isPascal]).Name := 'Linear4PointInterpolation_Pas';
+  GradientRegistry.BindingsByID[FID_LINEAR3].Add(@Linear3PointInterpolation_Pas, [isPascal]).name := 'Linear3PointInterpolation_Pas';
+  GradientRegistry.BindingsByID[FID_LINEAR4].Add(@Linear4PointInterpolation_Pas, [isPascal]).Name := 'Linear4PointInterpolation_Pas';
 
 {$IFNDEF PUREPASCAL}
 {$IFNDEF OMIT_SSE2}
-  GradientRegistry[FID_LINEAR3].Add(@Linear3PointInterpolation_SSE2, [isSSE2]).Name := 'Linear3PointInterpolation_SSE2';
-  GradientRegistry[FID_LINEAR4].Add(@Linear4PointInterpolation_SSE2, [isSSE2]).Name := 'Linear4PointInterpolation_SSE2';
+  GradientRegistry.BindingsByID[FID_LINEAR3].Add(@Linear3PointInterpolation_SSE2, [isSSE2]).Name := 'Linear3PointInterpolation_SSE2';
+  GradientRegistry.BindingsByID[FID_LINEAR4].Add(@Linear4PointInterpolation_SSE2, [isSSE2]).Name := 'Linear4PointInterpolation_SSE2';
 {$ENDIF}
 {$ENDIF}
 

--- a/Source/GR32_Filters.pas
+++ b/Source/GR32_Filters.pas
@@ -1672,29 +1672,29 @@ begin
   Registry.RegisterBinding(FID_ORLINEEX, @@LogicalMaskLineOrEx, 'LogicalMaskLineOrEx');
   Registry.RegisterBinding(FID_XORLINEEX, @@LogicalMaskLineXorEx, 'LogicalMaskLineXorEx');
 
-  Registry[FID_ANDLINE].Add(@AndLine_Pas, [isPascal]).Name := 'AndLine_Pas';
-  Registry[FID_ORLINE].Add(@OrLine_Pas, [isPascal]).Name := 'OrLine_Pas';
-  Registry[FID_XORLINE].Add(@XorLine_Pas, [isPascal]).Name := 'XorLine_Pas';
-  Registry[FID_ANDLINEEX].Add(@AndLineEx_Pas, [isPascal]).Name := 'AndLineEx_Pas';
-  Registry[FID_ORLINEEX].Add(@OrLineEx_Pas, [isPascal]).Name := 'OrLineEx_Pas';
-  Registry[FID_XORLINEEX].Add(@XorLineEx_Pas, [isPascal]).Name := 'XorLineEx_Pas';
+  Registry.BindingsByID[FID_ANDLINE].Add(@AndLine_Pas, [isPascal]).Name := 'AndLine_Pas';
+  Registry.BindingsByID[FID_ORLINE].Add(@OrLine_Pas, [isPascal]).Name := 'OrLine_Pas';
+  Registry.BindingsByID[FID_XORLINE].Add(@XorLine_Pas, [isPascal]).Name := 'XorLine_Pas';
+  Registry.BindingsByID[FID_ANDLINEEX].Add(@AndLineEx_Pas, [isPascal]).Name := 'AndLineEx_Pas';
+  Registry.BindingsByID[FID_ORLINEEX].Add(@OrLineEx_Pas, [isPascal]).Name := 'OrLineEx_Pas';
+  Registry.BindingsByID[FID_XORLINEEX].Add(@XorLineEx_Pas, [isPascal]).Name := 'XorLineEx_Pas';
 
 {$IFNDEF PUREPASCAL}
-  Registry[FID_ANDLINE].Add(@AndLine_ASM, [isAssembler]).Name := 'AndLine_ASM';
-  Registry[FID_ORLINE].Add(@OrLine_ASM, [isAssembler]).Name := 'OrLine_ASM';
-  Registry[FID_XORLINE].Add(@XorLine_ASM, [isAssembler]).Name := 'XorLine_ASM';
-  Registry[FID_ANDLINEEX].Add(@AndLineEx_ASM, [isAssembler]).Name := 'AndLineEx_ASM';
-  Registry[FID_ORLINEEX].Add(@OrLineEx_ASM, [isAssembler]).Name := 'OrLineEx_ASM';
-  Registry[FID_XORLINEEX].Add(@XorLineEx_ASM, [isAssembler]).Name := 'XorLineEx_ASM';
+  Registry.BindingsByID[FID_ANDLINE].Add(@AndLine_ASM, [isAssembler]).Name := 'AndLine_ASM';
+  Registry.BindingsByID[FID_ORLINE].Add(@OrLine_ASM, [isAssembler]).Name := 'OrLine_ASM';
+  Registry.BindingsByID[FID_XORLINE].Add(@XorLine_ASM, [isAssembler]).Name := 'XorLine_ASM';
+  Registry.BindingsByID[FID_ANDLINEEX].Add(@AndLineEx_ASM, [isAssembler]).Name := 'AndLineEx_ASM';
+  Registry.BindingsByID[FID_ORLINEEX].Add(@OrLineEx_ASM, [isAssembler]).Name := 'OrLineEx_ASM';
+  Registry.BindingsByID[FID_XORLINEEX].Add(@XorLineEx_ASM, [isAssembler]).Name := 'XorLineEx_ASM';
 
   // TODO : rewrite MMX implementations using SSE
 {$IFNDEF OMIT_MMX}
-  Registry[FID_ANDLINEEX].Add(@AndLineEx_MMX, [isMMX]).Name := 'AndLineEx_MMX';
-  Registry[FID_ORLINEEX].Add(@OrLineEx_MMX, [isMMX]).Name := 'OrLineEx_MMX';
-  Registry[FID_XORLINEEX].Add(@XorLineEx_MMX, [isMMX]).Name := 'XorLineEx_MMX';
-  Registry[FID_ANDLINEEX].Add(@AndLineEx_EMMX, [isExMMX]).Name := 'AndLineEx_EMMX';
-  Registry[FID_ORLINEEX].Add(@OrLineEx_EMMX, [isExMMX]).Name := 'OrLineEx_EMMX';
-  Registry[FID_XORLINEEX].Add(@XorLineEx_EMMX, [isExMMX]).Name := 'XorLineEx_EMMX';
+  Registry.BindingsByID[FID_ANDLINEEX].Add(@AndLineEx_MMX, [isMMX]).Name := 'AndLineEx_MMX';
+  Registry.BindingsByID[FID_ORLINEEX].Add(@OrLineEx_MMX, [isMMX]).Name := 'OrLineEx_MMX';
+  Registry.BindingsByID[FID_XORLINEEX].Add(@XorLineEx_MMX, [isMMX]).Name := 'XorLineEx_MMX';
+  Registry.BindingsByID[FID_ANDLINEEX].Add(@AndLineEx_EMMX, [isExMMX]).Name := 'AndLineEx_EMMX';
+  Registry.BindingsByID[FID_ORLINEEX].Add(@OrLineEx_EMMX, [isExMMX]).Name := 'OrLineEx_EMMX';
+  Registry.BindingsByID[FID_XORLINEEX].Add(@XorLineEx_EMMX, [isExMMX]).Name := 'XorLineEx_EMMX';
 {$ENDIF}
 
 {$ENDIF}

--- a/Source/GR32_MicroTiles.pas
+++ b/Source/GR32_MicroTiles.pas
@@ -1680,13 +1680,13 @@ begin
   Registry.RegisterBinding(FID_MICROTILEUNION, @@MicroTileUnion, 'MicroTileUnion');
   Registry.RegisterBinding(FID_MICROTILESUNION, @@MicroTilesU, 'MicroTilesU');
 
-  Registry[FID_MICROTILEUNION].Add(@MicroTileUnion_Pas, [isPascal]).Name := 'MicroTileUnion_Pas';
-  Registry[FID_MICROTILESUNION].Add(@MicroTilesUnion_Pas, [isPascal]).Name := 'MicroTilesUnion_Pas';
+  Registry.BindingsByID[FID_MICROTILEUNION].Add(@MicroTileUnion_Pas, [isPascal]).Name := 'MicroTileUnion_Pas';
+  Registry.BindingsByID[FID_MICROTILESUNION].Add(@MicroTilesUnion_Pas, [isPascal]).Name := 'MicroTilesUnion_Pas';
 
   // TODO : rewrite MMX implementations using SSE
 {$if (not defined(PUREPASCAL)) and (not defined(OMIT_MMX)) and defined(TARGET_x86)}
-  Registry[FID_MICROTILEUNION].Add(@MicroTileUnion_EMMX, [isExMMX]).Name := 'MicroTileUnion_EMMX';
-  Registry[FID_MICROTILESUNION].Add(@MicroTilesUnion_EMMX, [isExMMX]).Name := 'MicroTilesUnion_EMMX';
+  Registry.BindingsByID[FID_MICROTILEUNION].Add(@MicroTileUnion_EMMX, [isExMMX]).Name := 'MicroTileUnion_EMMX';
+  Registry.BindingsByID[FID_MICROTILESUNION].Add(@MicroTilesUnion_EMMX, [isExMMX]).Name := 'MicroTilesUnion_EMMX';
 {$ifend}
 
   Registry.RebindAll;


### PR DESCRIPTION
C++Builder can't compile overloaded properties (even if the Delphi->BCB translator is happy to create that code...), so there is a suffix now between them to avoid this. 

Apparently there is also a bug in FPC with those, so this should avoid both problems.

Changed the units where the Bindings were accessed by ID to use the new name, BindingsByID.