### PR TITLE
Minor improvements for the RenderText example:

### DIFF
--- a/Examples/Drawing/RenderText/MainUnit.dfm
+++ b/Examples/Drawing/RenderText/MainUnit.dfm
@@ -23,9 +23,8 @@ object FormRenderText: TFormRenderText
     BitmapAlign = baTopLeft
     Scale = 1.000000000000000000
     ScaleMode = smNormal
-    TabOrder = 0
+    TabOrder = 1
     OnResize = ImageResize
-    ExplicitWidth = 329
   end
   object PnlControl: TPanel
     Left = 0
@@ -40,8 +39,7 @@ object FormRenderText: TFormRenderText
     Font.Name = 'Tahoma'
     Font.Style = []
     ParentFont = False
-    TabOrder = 1
-    ExplicitWidth = 329
+    TabOrder = 0
     DesignSize = (
       566
       61)
@@ -68,19 +66,18 @@ object FormRenderText: TFormRenderText
       Anchors = [akLeft, akTop, akRight]
       AutoSize = False
       TabOrder = 0
-      Text = 'Excellence endures'
+      Text = 'Excellence endures 0123456789'
       OnChange = EditTextChange
     end
-    object BtnClickMe: TButton
-      Left = 490
+    object BtnRunBenchmark: TButton
+      Left = 418
       Top = 32
-      Width = 73
+      Width = 145
       Height = 21
       Anchors = [akTop, akRight]
-      Caption = 'Click me!'
-      TabOrder = 1
-      OnClick = BtnClickMeClick
-      ExplicitLeft = 253
+      Caption = 'Run Benchmark'
+      TabOrder = 2
+      OnClick = BtnRunBenchmarkClick
     end
     object CheckBoxAntiAlias: TCheckBox
       Left = 4
@@ -88,7 +85,7 @@ object FormRenderText: TFormRenderText
       Width = 97
       Height = 17
       Caption = 'Anti-alias'
-      TabOrder = 2
+      TabOrder = 3
       OnClick = CheckBoxAntiAliasClick
     end
     object CheckBoxCanvas32: TCheckBox
@@ -97,7 +94,7 @@ object FormRenderText: TFormRenderText
       Width = 97
       Height = 17
       Caption = 'TCanvas32'
-      TabOrder = 3
+      TabOrder = 4
       OnClick = CheckBoxCanvas32Click
     end
     object ComboBoxFont: TComboBox
@@ -106,9 +103,27 @@ object FormRenderText: TFormRenderText
       Width = 145
       Height = 21
       Anchors = [akTop, akRight]
-      TabOrder = 4
+      TabOrder = 1
       Text = 'ComboBoxFont'
       OnChange = ComboBoxFontChange
+    end
+    object CheckBoxBold: TCheckBox
+      Left = 227
+      Top = 34
+      Width = 62
+      Height = 17
+      Caption = 'Bold'
+      TabOrder = 5
+      OnClick = CheckBoxBoldClick
+    end
+    object CheckBoxItalic: TCheckBox
+      Left = 307
+      Top = 34
+      Width = 62
+      Height = 17
+      Caption = 'Italic'
+      TabOrder = 6
+      OnClick = CheckBoxItalicClick
     end
   end
 end

--- a/Examples/Drawing/RenderText/MainUnit.pas
+++ b/Examples/Drawing/RenderText/MainUnit.pas
@@ -45,7 +45,7 @@ uses
 
 type
   TFormRenderText = class(TForm)
-    BtnClickMe: TButton;
+    BtnRunBenchmark: TButton;
     EditText: TEdit;
     Image: TImage32;
     LblEnterText: TLabel;
@@ -54,13 +54,17 @@ type
     CheckBoxCanvas32: TCheckBox;
     ComboBoxFont: TComboBox;
     Label1: TLabel;
+    CheckBoxBold: TCheckBox;
+    CheckBoxItalic: TCheckBox;
     procedure FormCreate(Sender: TObject);
-    procedure BtnClickMeClick(Sender: TObject);
+    procedure BtnRunBenchmarkClick(Sender: TObject);
     procedure EditTextChange(Sender: TObject);
     procedure ImageResize(Sender: TObject);
     procedure CheckBoxAntiAliasClick(Sender: TObject);
     procedure CheckBoxCanvas32Click(Sender: TObject);
     procedure ComboBoxFontChange(Sender: TObject);
+    procedure CheckBoxBoldClick(Sender: TObject);
+    procedure CheckBoxItalicClick(Sender: TObject);
   public
     procedure Draw;
   end;
@@ -108,16 +112,26 @@ var
   y: integer;
   Height: integer;
   Size: integer;
+  Style: TFontStyles;
   Canvas: TCanvas32;
   Brush: TSolidBrush;
 begin
   Image.Bitmap.Clear;
 
-  y := 0;
+  y := 3;
   Size := 6;
 
   Image.Bitmap.Font.Size := 20;
-  Image.Bitmap.Font.Style := [fsBold, fsItalic];
+
+  Style := [];
+
+  if CheckBoxBold.Checked then
+    Include(Style, fsBold);
+
+  if CheckBoxItalic.Checked then
+    Include(Style, fsItalic);
+
+  Image.Bitmap.Font.Style := Style;
 
   Canvas := nil;
   try
@@ -132,8 +146,6 @@ begin
     while (y < Image.Bitmap.Height) do
     begin
       Image.Bitmap.Font.Size := Size;
-      Height := Image.Bitmap.TextHeight(EditText.Text);
-      y := y + MulDiv(Height, 3, 5);
 
       if (Canvas <> nil) then
         Canvas.RenderText(10, y, Format('%d: %s', [Size, EditText.Text]))
@@ -141,6 +153,9 @@ begin
         Image.Bitmap.RenderText(10, y, Format('%d: %s', [Size, EditText.Text]), clWhite32, CheckBoxAntiAlias.Checked);
 
       Size := Trunc(Size * 1.2);
+
+      Height := Image.Bitmap.TextHeight(EditText.Text);
+      y := y + MulDiv(Height, 8, 10);
     end;
   finally
     Canvas.Free;
@@ -158,7 +173,7 @@ begin
   Draw;
 end;
 
-procedure TFormRenderText.BtnClickMeClick(Sender: TObject);
+procedure TFormRenderText.BtnRunBenchmarkClick(Sender: TObject);
 var
   SaveQuality: TFontQuality;
   i: Integer;
@@ -256,6 +271,16 @@ procedure TFormRenderText.CheckBoxCanvas32Click(Sender: TObject);
 begin
   CheckBoxAntiAlias.Enabled := not CheckBoxCanvas32.Checked;
   Update;
+  Draw;
+end;
+
+procedure TFormRenderText.CheckBoxItalicClick(Sender: TObject);
+begin
+  Draw;
+end;
+
+procedure TFormRenderText.CheckBoxBoldClick(Sender: TObject);
+begin
   Draw;
 end;
 


### PR DESCRIPTION
  - add checkboxes Bold and Italic to customize font style
  - rename button "Click me!" to "Run Benchmark"
  - fix rendered text alignment (add more space between text lines)